### PR TITLE
Persist settings on exit

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -224,6 +224,9 @@ namespace EyeBreakEnforcer
         protected override void OnExit(ExitEventArgs e)
         {
             // Clean up resources
+            // Save current settings before disposing services
+            _settingsService?.SaveSettings(_settingsService.CurrentSettings);
+
             _statusUpdateTimer?.Stop();
             _timerService?.Stop();
             _timerService?.Dispose();


### PR DESCRIPTION
## Summary
- save user settings before cleaning up services in `App.OnExit`
- verify `SettingsWindow` triggers `SettingsChanged` in `SaveButton_Click`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e5b1b6cc8325ba05fdd21d6a36aa