### PR TITLE
Update overlay sizing for multi-display

### DIFF
--- a/Windows/OverlayWindow.xaml
+++ b/Windows/OverlayWindow.xaml
@@ -3,7 +3,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="EyeBreakEnforcer Overlay"
         WindowStyle="None"
-        WindowState="Maximized"
         Topmost="True"
         AllowsTransparency="True"
         Background="Black"

--- a/Windows/OverlayWindow.xaml.cs
+++ b/Windows/OverlayWindow.xaml.cs
@@ -29,10 +29,16 @@ namespace EyeBreakEnforcer.Windows
             if (_settings.CoverAllMonitors)
             {
                 var totalBounds = GetTotalScreenBounds();
+                WindowState = WindowState.Normal;
                 Left = totalBounds.Left;
                 Top = totalBounds.Top;
                 Width = totalBounds.Width;
                 Height = totalBounds.Height;
+            }
+            else
+            {
+                // Default to maximizing on the current monitor
+                WindowState = WindowState.Maximized;
             }
         }
 


### PR DESCRIPTION
## Summary
- let OverlayWindow choose window state based on settings
- remove Maximized from OverlayWindow.xaml so we can size it manually

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846e5ba1118832582d0bab375cf9755