### PR TITLE
Add timed pause options

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -57,6 +57,7 @@ namespace EyeBreakEnforcer
             _trayIconManager.SettingsRequested += OnSettingsRequested;
             _trayIconManager.PauseRequested += OnPauseRequested;
             _trayIconManager.ResumeRequested += OnResumeRequested;
+            _trayIconManager.PauseForRequested += OnPauseForRequested;
             _trayIconManager.ExitRequested += OnExitRequested;
             _trayIconManager.Initialize();
         }
@@ -197,6 +198,19 @@ namespace EyeBreakEnforcer
             }
         }
 
+        private void OnPauseForRequested(TimeSpan duration)
+        {
+            _timerService?.PauseFor(duration);
+            _trayIconManager?.SetPausedState(true);
+
+            if (_settingsService?.CurrentSettings.ShowNotifications == true)
+            {
+                var minutes = (int)duration.TotalMinutes;
+                string text = $"Eye protection reminders paused for {minutes} minute" + (minutes == 1 ? "" : "s") + ".";
+                _trayIconManager?.ShowBalloonTip("Paused", text, System.Windows.Forms.ToolTipIcon.Info);
+            }
+        }
+
         private void OnExitRequested()
         {
             var result = System.Windows.MessageBox.Show("Are you sure you want to exit EyeBreakEnforcer?", 
@@ -216,8 +230,9 @@ namespace EyeBreakEnforcer
             {
                 var nextBlink = _timerService.GetTimeUntilNextBlink();
                 var nextBreak = _timerService.GetTimeUntilNextBreak();
-                
-                _trayIconManager.UpdateStatus(_timerService.IsRunning, nextBlink, nextBreak);
+                var resumeIn = _timerService.GetTimeUntilResume();
+
+                _trayIconManager.UpdateStatus(_timerService.IsRunning, nextBlink, nextBreak, resumeIn);
             }
         }
 

--- a/Services/TimerService.cs
+++ b/Services/TimerService.cs
@@ -7,28 +7,36 @@ namespace EyeBreakEnforcer.Services
     {
         private readonly System.Timers.Timer _blinkTimer;
         private readonly System.Timers.Timer _breakTimer;
+        private readonly System.Timers.Timer _resumeTimer;
         private AppSettings _settings;
         private bool _isPaused;
+        private DateTime? _resumeTime;
 
         public event Action? BlinkReminderTriggered;
         public event Action? BreakReminderTriggered;
 
         public bool IsRunning { get; private set; }
+        public bool IsPaused => _isPaused;
         public DateTime? NextBlinkTime { get; private set; }
         public DateTime? NextBreakTime { get; private set; }
+        public DateTime? ResumeTime => _resumeTime;
 
         public TimerService(AppSettings settings)
         {
             _settings = settings;
-            
+
             _blinkTimer = new System.Timers.Timer();
             _blinkTimer.Elapsed += OnBlinkTimerElapsed;
             _blinkTimer.AutoReset = true;
-            
+
             _breakTimer = new System.Timers.Timer();
             _breakTimer.Elapsed += OnBreakTimerElapsed;
             _breakTimer.AutoReset = true;
-            
+
+            _resumeTimer = new System.Timers.Timer();
+            _resumeTimer.Elapsed += OnResumeTimerElapsed;
+            _resumeTimer.AutoReset = false;
+
             UpdateTimerIntervals();
         }
 
@@ -59,10 +67,12 @@ namespace EyeBreakEnforcer.Services
         {
             _blinkTimer.Stop();
             _breakTimer.Stop();
+            _resumeTimer.Stop();
             IsRunning = false;
             _isPaused = false;
             NextBlinkTime = null;
             NextBreakTime = null;
+            _resumeTime = null;
         }
 
         public void Pause()
@@ -71,6 +81,8 @@ namespace EyeBreakEnforcer.Services
             {
                 _blinkTimer.Stop();
                 _breakTimer.Stop();
+                _resumeTimer.Stop();
+                _resumeTime = null;
                 _isPaused = true;
             }
         }
@@ -79,6 +91,8 @@ namespace EyeBreakEnforcer.Services
         {
             if (_isPaused)
             {
+                _resumeTimer.Stop();
+                _resumeTime = null;
                 if (_settings.BlinkReminderEnabled)
                 {
                     _blinkTimer.Start();
@@ -93,6 +107,17 @@ namespace EyeBreakEnforcer.Services
 
                 _isPaused = false;
             }
+        }
+
+        public void PauseFor(TimeSpan duration)
+        {
+            if (!IsRunning)
+                return;
+
+            Pause();
+            _resumeTimer.Interval = duration.TotalMilliseconds;
+            _resumeTimer.Start();
+            _resumeTime = DateTime.Now.Add(duration);
         }
 
         public void SnoozeBreak()
@@ -171,6 +196,11 @@ namespace EyeBreakEnforcer.Services
             }
         }
 
+        private void OnResumeTimerElapsed(object? sender, ElapsedEventArgs e)
+        {
+            Resume();
+        }
+
         public TimeSpan GetTimeUntilNextBlink()
         {
             if (NextBlinkTime.HasValue && IsRunning)
@@ -191,10 +221,21 @@ namespace EyeBreakEnforcer.Services
             return TimeSpan.Zero;
         }
 
+        public TimeSpan GetTimeUntilResume()
+        {
+            if (_resumeTime.HasValue && _isPaused)
+            {
+                var timeLeft = _resumeTime.Value - DateTime.Now;
+                return timeLeft > TimeSpan.Zero ? timeLeft : TimeSpan.Zero;
+            }
+            return TimeSpan.Zero;
+        }
+
         public void Dispose()
         {
             _blinkTimer?.Dispose();
             _breakTimer?.Dispose();
+            _resumeTimer?.Dispose();
         }
     }
 } 

--- a/Services/TrayIconManager.cs
+++ b/Services/TrayIconManager.cs
@@ -106,9 +106,23 @@ namespace EyeBreakEnforcer.Services
                     pauseInfo = $" ({FormatTime(resumeIn.Value)})";
                 }
                 status = $"EyeBreakEnforcer - Paused{pauseInfo}";
+
+                var pauseResumeItem = _contextMenu?.Items["PauseResume"] as ToolStripMenuItem;
+                if (pauseResumeItem != null)
+                {
+                    pauseResumeItem.Text = resumeIn.HasValue && resumeIn.Value > TimeSpan.Zero
+                        ? $"Resume ({FormatTime(resumeIn.Value)})"
+                        : "Resume";
+                }
             }
             else
             {
+                var pauseResumeItem = _contextMenu?.Items["PauseResume"] as ToolStripMenuItem;
+                if (pauseResumeItem != null)
+                {
+                    pauseResumeItem.Text = "Pause";
+                }
+
                 var nextEvent = "";
                 if (nextBlink.HasValue)
                 {

--- a/Services/TrayIconManager.cs
+++ b/Services/TrayIconManager.cs
@@ -12,6 +12,7 @@ namespace EyeBreakEnforcer.Services
         public event Action? SettingsRequested;
         public event Action? PauseRequested;
         public event Action? ResumeRequested;
+        public event Action<TimeSpan>? PauseForRequested;
         public event Action? ExitRequested;
 
         public void Initialize()
@@ -26,6 +27,8 @@ namespace EyeBreakEnforcer.Services
 
             var settingsItem = new ToolStripMenuItem("Settings", null, OnSettingsClick);
             var pauseResumeItem = new ToolStripMenuItem("Pause", null, OnPauseResumeClick) { Name = "PauseResume" };
+            var pause5Item = new ToolStripMenuItem("Pause 5 min", null, (s, e) => OnTimedPauseClick(TimeSpan.FromMinutes(5)));
+            var pause1hItem = new ToolStripMenuItem("Pause 1 h", null, (s, e) => OnTimedPauseClick(TimeSpan.FromHours(1)));
             var separatorItem = new ToolStripSeparator();
             var exitItem = new ToolStripMenuItem("Exit", null, OnExitClick);
 
@@ -33,6 +36,8 @@ namespace EyeBreakEnforcer.Services
             {
                 settingsItem,
                 pauseResumeItem,
+                pause5Item,
+                pause1hItem,
                 separatorItem,
                 exitItem
             });
@@ -65,7 +70,26 @@ namespace EyeBreakEnforcer.Services
             return Icon.FromHandle(bitmap.GetHicon());
         }
 
-        public void UpdateStatus(bool isRunning, TimeSpan? nextBlink = null, TimeSpan? nextBreak = null)
+        private static string FormatTime(TimeSpan time)
+        {
+            var totalSeconds = (int)time.TotalSeconds;
+            if (totalSeconds >= 3600)
+            {
+                var hours = totalSeconds / 3600;
+                var minutes = (totalSeconds % 3600) / 60;
+                return $"{hours}h{minutes}m";
+            }
+            else if (totalSeconds >= 60)
+            {
+                var minutes = totalSeconds / 60;
+                var seconds = totalSeconds % 60;
+                return $"{minutes}m{seconds}s";
+            }
+
+            return $"{totalSeconds}s";
+        }
+
+        public void UpdateStatus(bool isRunning, TimeSpan? nextBlink = null, TimeSpan? nextBreak = null, TimeSpan? resumeIn = null)
         {
             if (_notifyIcon == null) return;
 
@@ -76,7 +100,12 @@ namespace EyeBreakEnforcer.Services
             }
             else if (_isPaused)
             {
-                status = "EyeBreakEnforcer - Paused";
+                var pauseInfo = string.Empty;
+                if (resumeIn.HasValue && resumeIn.Value > TimeSpan.Zero)
+                {
+                    pauseInfo = $" ({FormatTime(resumeIn.Value)})";
+                }
+                status = $"EyeBreakEnforcer - Paused{pauseInfo}";
             }
             else
             {
@@ -132,6 +161,11 @@ namespace EyeBreakEnforcer.Services
             {
                 PauseRequested?.Invoke();
             }
+        }
+
+        private void OnTimedPauseClick(TimeSpan duration)
+        {
+            PauseForRequested?.Invoke(duration);
         }
 
         private void OnExitClick(object? sender, EventArgs e)


### PR DESCRIPTION
## Summary
- add resume timer logic in `TimerService` with new `PauseFor` method
- show remaining pause time in tray icon
- expose tray menu actions for timed pauses
- handle timed pauses in application logic

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e5c8eb7c8325ae9244226efa12f0