### PR TITLE
Implement click-through overlay for blink flash

### DIFF
--- a/Windows/OverlayWindow.xaml.cs
+++ b/Windows/OverlayWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Media;
 using System.Windows.Threading;
 using System.Runtime.InteropServices;
 using System.Windows.Interop;
+using System.Linq;
 
 namespace EyeBreakEnforcer.Windows
 {
@@ -54,10 +55,15 @@ namespace EyeBreakEnforcer.Windows
             if (_settings.CoverAllMonitors)
             {
                 var totalBounds = GetTotalScreenBounds();
+                WindowState = WindowState.Normal;
                 Left = totalBounds.Left;
                 Top = totalBounds.Top;
                 Width = totalBounds.Width;
                 Height = totalBounds.Height;
+            }
+            else
+            {
+                WindowState = WindowState.Maximized;
             }
         }
 

--- a/Windows/OverlayWindow.xaml.cs
+++ b/Windows/OverlayWindow.xaml.cs
@@ -3,6 +3,8 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
+using System.Runtime.InteropServices;
+using System.Windows.Interop;
 
 namespace EyeBreakEnforcer.Windows
 {
@@ -15,6 +17,29 @@ namespace EyeBreakEnforcer.Windows
         private Action? _onBreakComplete;
         private Action? _onBreakSkipped;
         private Action? _onBreakSnoozed;
+
+        private const int GWL_EXSTYLE = -20;
+        private const int WS_EX_TRANSPARENT = 0x00000020;
+
+        [DllImport("user32.dll")]
+        private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+        [DllImport("user32.dll")]
+        private static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
+        private void EnableClickThrough()
+        {
+            var hwnd = new WindowInteropHelper(this).Handle;
+            int styles = GetWindowLong(hwnd, GWL_EXSTYLE);
+            SetWindowLong(hwnd, GWL_EXSTYLE, styles | WS_EX_TRANSPARENT);
+        }
+
+        private void DisableClickThrough()
+        {
+            var hwnd = new WindowInteropHelper(this).Handle;
+            int styles = GetWindowLong(hwnd, GWL_EXSTYLE);
+            SetWindowLong(hwnd, GWL_EXSTYLE, styles & ~WS_EX_TRANSPARENT);
+        }
 
         public OverlayWindow()
         {
@@ -60,9 +85,11 @@ namespace EyeBreakEnforcer.Windows
             Background = new SolidColorBrush(System.Windows.Media.Color.FromRgb(color.R, color.G, color.B));
             
             SetupWindow();
+            IsHitTestVisible = false;
+            Focusable = false;
+            Topmost = true;
             Show();
-            Activate();
-            Focus();
+            EnableClickThrough();
             
             // Auto-hide after specified duration
             var timer = new DispatcherTimer();
@@ -71,6 +98,9 @@ namespace EyeBreakEnforcer.Windows
             {
                 timer.Stop();
                 Hide();
+                DisableClickThrough();
+                IsHitTestVisible = true;
+                Focusable = true;
             };
             timer.Start();
         }
@@ -83,6 +113,10 @@ namespace EyeBreakEnforcer.Windows
             _onBreakSkipped = onSkipped;
             _onBreakSnoozed = onSnoozed;
             _remainingSeconds = settings.BreakDurationSeconds;
+
+            DisableClickThrough();
+            IsHitTestVisible = true;
+            Focusable = true;
             
             // Set background color
             var color = settings.GetBreakColor();


### PR DESCRIPTION
## Summary
- allow OverlayWindow to ignore user input while flashing
- use Win32 interop to set `WS_EX_TRANSPARENT`
- keep break mode interactive

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e5ecc3008325ba3346a417d9982f