### PR TITLE
Update overlay sizing for multi-display

### DIFF
--- a/Windows/OverlayWindow.xaml
+++ b/Windows/OverlayWindow.xaml
@@ -3,7 +3,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="EyeBreakEnforcer Overlay"
         WindowStyle="None"
-        WindowState="Maximized"
         Topmost="True"
         AllowsTransparency="True"
         Background="Black"

--- a/Windows/OverlayWindow.xaml.cs
+++ b/Windows/OverlayWindow.xaml.cs
@@ -29,10 +29,16 @@ namespace EyeBreakEnforcer.Windows
             if (_settings.CoverAllMonitors)
             {
                 var totalBounds = GetTotalScreenBounds();
+                WindowState = WindowState.Normal;
                 Left = totalBounds.Left;
                 Top = totalBounds.Top;
                 Width = totalBounds.Width;
                 Height = totalBounds.Height;
+            }
+            else
+            {
+                // Default to maximizing on the current monitor
+                WindowState = WindowState.Maximized;
             }
         }
 

--- a/Windows/OverlayWindow.xaml.cs
+++ b/Windows/OverlayWindow.xaml.cs
@@ -44,13 +44,13 @@ namespace EyeBreakEnforcer.Windows
 
         private Rect GetTotalScreenBounds()
         {
-            var screens = System.Windows.Forms.Screen.AllScreens;
-            var left = screens.Min(s => s.Bounds.Left);
-            var top = screens.Min(s => s.Bounds.Top);
-            var right = screens.Max(s => s.Bounds.Right);
-            var bottom = screens.Max(s => s.Bounds.Bottom);
-            
-            return new Rect(left, top, right - left, bottom - top);
+            // Use SystemParameters to get the virtual screen size in
+            // device-independent units so that DPI scaling is handled
+            return new Rect(
+                SystemParameters.VirtualScreenLeft,
+                SystemParameters.VirtualScreenTop,
+                SystemParameters.VirtualScreenWidth,
+                SystemParameters.VirtualScreenHeight);
         }
 
         public void ShowBlinkFlash(AppSettings settings)


### PR DESCRIPTION
## Summary
- let OverlayWindow choose window state based on settings
- remove Maximized from OverlayWindow.xaml so we can size it manually

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846e5ba1118832582d0bab375cf9755